### PR TITLE
Avoid statusbar crash in iOS 13

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGallery/MHGallery.m
@@ -62,13 +62,17 @@ UIImage *MHDefaultImageForFrame(CGRect frame){
 }
 
 UIView *MHStatusBar(void){
-    NSString *key = [NSString.alloc initWithData:[NSData dataWithBytes:(unsigned char []){0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x42, 0x61, 0x72} length:9] encoding:NSASCIIStringEncoding];
-    id object = UIApplication.sharedApplication;
-    UIView *statusBar;
-    if ([object respondsToSelector:NSSelectorFromString(key)]) {
-        statusBar = [object valueForKey:key];
+    if (@available(iOS 13, *)) {
+        return nil;
+    } else {
+        NSString *key = [NSString.alloc initWithData:[NSData dataWithBytes:(unsigned char []){0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x42, 0x61, 0x72} length:9] encoding:NSASCIIStringEncoding];
+        id object = UIApplication.sharedApplication;
+        UIView *statusBar;
+        if ([object respondsToSelector:NSSelectorFromString(key)]) {
+            statusBar = [object valueForKey:key];
+        }
+        return statusBar;
     }
-    return statusBar;
 }
 
 BOOL MHShouldShowStatusBar(void){


### PR DESCRIPTION
Just a touchup to avoid a crash. We don't even seem to change the status bar anyways, but just calling it gets the crash.