### PR TITLE
Fix crash in media browser

### DIFF
--- a/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
+++ b/MHVideoPhotoGallery/MMHVideoPhotoGallery/MHGalleryImageViewerViewController/MHGalleryImageViewerViewController.m
@@ -108,6 +108,10 @@
     if ([self numberOfGalleryItems] > self.pageIndex) {
         MHGalleryItem *item = [self itemForIndex:self.pageIndex];
         
+        if (item == NULL) {
+            return;
+        }
+        
         MHImageViewController *imageViewController = [MHImageViewController imageViewControllerForMHMediaItem:item viewController:self];
         imageViewController.pageIndex = self.pageIndex;
         [self.pageViewController setViewControllers:@[imageViewController]


### PR DESCRIPTION
Check for null item in reloadData() since we will change itemForIndex to possibly return NULL. 